### PR TITLE
Got Rid of ROS1 Unique Dependencies and Fixed Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you choose to install MSCL at a location other than /usr/share, [CMakeLists.t
 #### Launch the node and publish data
 The following command will launch the driver. Keep in mind each instance needs to be run in a separate terminal.
             
-        ros2 launch ros_mscl microstrain_launch.py
+        ros2 launch ros2_mscl microstrain_launch.py
 
 Some optional launch parameters:
 - name: namespace the node will publish messages to, default: gx5

--- a/ros2_mscl/CMakeLists.txt
+++ b/ros2_mscl/CMakeLists.txt
@@ -35,8 +35,10 @@ find_package(ros2_mscl_msgs REQUIRED)
 
 
 find_library(MSCL_LIB_PATH NAMES libmscl.so PATHS "/usr/share/c++-mscl" DOC "MSCL Library" NO_DEFAULT_PATH)
+find_library(BOOST_LIB_PATH NAMES libboost_chrono.so PATHS "/usr/share/c++-mscl/Boost/lib" NO_DEFAULT_PATH)
 set(MSCL_INC_PATH "/usr/share/c++-mscl/source")
 set(MSCL_LIB "/usr/share/c++-mscl")
+set(BOOST_INC_PATH "/usr/share/c++-mscl/Boost/include")
 
 set(srv_files
   "srv/DeviceSettings.srv"

--- a/ros2_mscl/CMakeLists.txt
+++ b/ros2_mscl/CMakeLists.txt
@@ -35,10 +35,8 @@ find_package(ros2_mscl_msgs REQUIRED)
 
 
 find_library(MSCL_LIB_PATH NAMES libmscl.so PATHS "/usr/share/c++-mscl" DOC "MSCL Library" NO_DEFAULT_PATH)
-find_library(BOOST_LIB_PATH NAMES libboost_chrono.so PATHS "/usr/share/c++-mscl/Boost/lib" NO_DEFAULT_PATH)
 set(MSCL_INC_PATH "/usr/share/c++-mscl/source")
 set(MSCL_LIB "/usr/share/c++-mscl")
-set(BOOST_INC_PATH "/usr/share/c++-mscl/Boost/include")
 
 set(srv_files
   "srv/DeviceSettings.srv"

--- a/ros2_mscl/package.xml
+++ b/ros2_mscl/package.xml
@@ -12,12 +12,8 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>rclcpp_lifecycle</exec_depend>
-  <exec_depend>message_runtime</exec_depend>
   <exec_depend>diagnostic_aggregator</exec_depend>
   
-  <depend>roscpp</depend>
-  <depend>roscpp_components</depend>
-  <depend>cmake_modules</depend>
   <depend>diagnostic_updater</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
@@ -31,9 +27,6 @@
   <depend>lifecycle_msgs</depend>
   
   <build_depend>rclcpp_lifecycle</build_depend>
-  <build_depend>message_generation</build_depend>
-  <build_depend>roslint</build_depend>
-  <build_depend>libmscl</build_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
  
   <export>


### PR DESCRIPTION
We found that these dependencies are not found in Foxy and think you may have pulled them from the old package.xml from the ROS1 version of this repo. We removed all the ones that were not found in Foxy.

Also, the README is missing a '2' in the package name.