### PR TITLE
Installing Launch File So It Can Be Found

### DIFF
--- a/ros2_mscl/CMakeLists.txt
+++ b/ros2_mscl/CMakeLists.txt
@@ -140,6 +140,7 @@ target_link_libraries(ros2_mscl_node ${MSCL_LIB_PATH})
 
 install(TARGETS
   ros2_mscl_node
+  DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )

--- a/ros2_mscl/CMakeLists.txt
+++ b/ros2_mscl/CMakeLists.txt
@@ -140,9 +140,13 @@ target_link_libraries(ros2_mscl_node ${MSCL_LIB_PATH})
 
 install(TARGETS
   ros2_mscl_node
-  DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
   RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}/
 )
 
 #############


### PR DESCRIPTION
Without this, it wasn't possible to locate the file `microstrain_launch.py`